### PR TITLE
Chainable setter methods

### DIFF
--- a/src/PHPInfo.php
+++ b/src/PHPInfo.php
@@ -23,6 +23,8 @@ class PHPInfo
             'mode' => 'text',
             'data' => $phpInfo
         );
+
+		return $this;
     }
 
     public function setHTML($phpInfo) {
@@ -30,6 +32,8 @@ class PHPInfo
             'mode' => 'html',
             'data' => $phpInfo
         );
+
+		return $this;
     }
 
     public function get() {

--- a/src/PHPInfo.php
+++ b/src/PHPInfo.php
@@ -24,7 +24,7 @@ class PHPInfo
             'data' => $phpInfo
         );
 
-		return $this;
+        return $this;
     }
 
     public function setHTML($phpInfo) {
@@ -33,7 +33,7 @@ class PHPInfo
             'data' => $phpInfo
         );
 
-		return $this;
+        return $this;
     }
 
     public function get() {


### PR DESCRIPTION
This PR allows you to chain the setter methods for a more clean and concise API
```php
use OutCompute\PHPInfo\PHPInfo;

// current version:
function get_phpinfo_array()
{
	ob_start();
	phpinfo();
	$php_info_as_string = ob_get_contents();
	ob_get_clean();

	$phpinfo = new OutCompute\PHPInfo\PHPInfo();
	$phpinfo->setText($php_info_as_string);
	return $phpinfo->get();
}
// with method chaining:
function get_phpinfo_array()
{
	ob_start();
	phpinfo();
	$php_info_as_string = ob_get_contents();
	ob_get_clean();

	return (new OutCompute\PHPInfo\PHPInfo())  // <- here is the method chain
		->setText($php_info_as_string)     // <- here is the method chain
		->get();                           // <- here is the method chain
}
```